### PR TITLE
Fix -reindex flag crashing startcoind

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2267,7 +2267,7 @@ bool CBlock::AcceptBlock(CValidationState &state, CDiskBlockPos *dbp)
     }
 
     // check that the block satisfies synchronized checkpoint
-    // Gaurd agains null pointer (pindexPrev) on genisis block
+    // guard against null pointer (pindexPrev) on genisis block
     // was causing -reindex to crash startcoind
     if (hash != hashGenesisBlock) {
         if (IsSyncCheckpointEnforced() // checkpoint enforce mode

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2267,9 +2267,13 @@ bool CBlock::AcceptBlock(CValidationState &state, CDiskBlockPos *dbp)
     }
 
     // check that the block satisfies synchronized checkpoint
-   if (IsSyncCheckpointEnforced() // checkpoint enforce mode
-       && !CheckSyncCheckpoint(hash, pindexPrev))
-       return error("AcceptBlock() : rejected by synchronized checkpoint");
+    // Gaurd agains null pointer (pindexPrev) on genisis block
+    // was causing -reindex to crash startcoind
+    if (hash != hashGenesisBlock) {
+        if (IsSyncCheckpointEnforced() // checkpoint enforce mode
+            && !CheckSyncCheckpoint(hash, pindexPrev))
+            return error("AcceptBlock() : rejected by synchronized checkpoint");
+    }
 
     // Write block to history file
     try {


### PR DESCRIPTION
When running startcoind with the -reindex flag it will crash with a segmentation error on loading the genesis block.

This is caused by the pindexPrev pointer to the previous block being null for the genesis block.

I have tested on my local node running on Ubuntu 14.04.4 LTS. but still needs to be tested on other platforms.